### PR TITLE
シングルトン処理の修正

### DIFF
--- a/demo/src/main/java/com/example/demo/BatchConfig.java
+++ b/demo/src/main/java/com/example/demo/BatchConfig.java
@@ -8,19 +8,24 @@ import com.example.demo.tasklet.CsvExistsCheckTasklet1;
 import com.example.demo.tasklet.CsvExistsCheckTasklet2;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.file.MultiResourceItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.io.IOException;
 import java.io.PrintStream;
 
 @Configuration
+@PropertySource("classpath:property/demo.properties")
 public class BatchConfig {
 
   @Autowired
@@ -36,6 +41,12 @@ public class BatchConfig {
   private CsvWriter writer;
 
   @Bean
+  @StepScope
+  public MultiResourceItemReader<User> read(@Value("${csv.file.path}") final String filePath) throws IOException {
+    return reader.read(filePath);
+  }
+
+  @Bean
   public Step fileCheckStep(final JobRepository jobRepository, final PlatformTransactionManager transactionManager) {
     return new StepBuilder("fileCheckStep", jobRepository)
             .tasklet(tasklet, transactionManager)
@@ -43,10 +54,12 @@ public class BatchConfig {
   }
 
   @Bean
-  public Step demoStep(final JobRepository jobRepository, final PlatformTransactionManager transactionManager) throws IOException {
+  public Step demoStep(final JobRepository jobRepository, final PlatformTransactionManager transactionManager, final MultiResourceItemReader<User> read) throws IOException {
+    System.out.println("step");
     return new StepBuilder("demoStep", jobRepository)
             .<User, User>chunk(10, transactionManager)
-            .reader(reader.read())
+//            .reader(read(null)) // 引数でreadをDIしない場合はこちらを使用する
+            .reader(read)
             .processor(processor)
             .writer(writer)
             .build();
@@ -55,6 +68,7 @@ public class BatchConfig {
   @Bean
   public Job demoJob(final JobRepository jobRepository, final PlatformTransactionManager transactionManager,
                      final Step fileCheckStep, final Step demoStep) throws Exception {
+    System.out.println("job");
     System.setOut(new PrintStream(System.out, true, "UTF-8"));
     return new JobBuilder("demoJob", jobRepository)
             .incrementer(new RunIdIncrementer())

--- a/demo/src/main/java/com/example/demo/chunk/CsvReader.java
+++ b/demo/src/main/java/com/example/demo/chunk/CsvReader.java
@@ -1,13 +1,10 @@
 package com.example.demo.chunk;
 
 import com.example.demo.model.User;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.file.FlatFileItemReader;
 import org.springframework.batch.item.file.MultiResourceItemReader;
 import org.springframework.batch.item.file.builder.FlatFileItemReaderBuilder;
 import org.springframework.batch.item.file.mapping.BeanWrapperFieldSetMapper;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Component;
@@ -16,21 +13,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Component
-@PropertySource("classpath:property/demo.properties")
 public class CsvReader {
 
-  @Value("${csv.file.path}")
-  private String filePath;
-
-  private Resource[] getCsvFiles() throws IOException {
+  private Resource[] getCsvFiles(final String filePath) throws IOException {
     return new PathMatchingResourcePatternResolver().getResources(filePath);
   }
 
-  @StepScope
-  public MultiResourceItemReader<User> read() throws IOException {
+  public MultiResourceItemReader<User> read(final String filePath) throws IOException {
     System.out.println("read");
     final MultiResourceItemReader<User> multiReader = new MultiResourceItemReader<>();
-    multiReader.setResources(getCsvFiles());
+    multiReader.setResources(getCsvFiles(filePath));
     multiReader.setDelegate(singleFileReader());
 
     return multiReader;

--- a/demo/src/main/java/com/example/demo/tasklet/CsvExistsCheckTasklet1.java
+++ b/demo/src/main/java/com/example/demo/tasklet/CsvExistsCheckTasklet1.java
@@ -28,6 +28,7 @@ public class CsvExistsCheckTasklet1 implements Tasklet {
 
   @Override
   public RepeatStatus execute(StepContribution stepContribution, ChunkContext context) throws IOException {
+    System.out.println("tasklet1");
     final Resource[] resources = csvResource.getResources(filePath);
     if (resources.length == 0) throw new FileNotFoundException("csvファイルが見つかりませんでした");
     return RepeatStatus.FINISHED;

--- a/demo/src/main/java/com/example/demo/tasklet/CsvExistsCheckTasklet2.java
+++ b/demo/src/main/java/com/example/demo/tasklet/CsvExistsCheckTasklet2.java
@@ -24,6 +24,7 @@ public class CsvExistsCheckTasklet2 implements Tasklet {
 
   @Override
   public RepeatStatus execute(StepContribution stepContribution, ChunkContext context) throws IOException {
+    System.out.println("tasklet2");
     final Resource[] resources = new PathMatchingResourcePatternResolver().getResources(filePath);
     if (resources.length == 0) throw new FileNotFoundException("csvファイルが見つかりませんでした");
     return RepeatStatus.FINISHED;

--- a/demo/src/test/java/com/example/demo/BatchConfigTest.java
+++ b/demo/src/test/java/com/example/demo/BatchConfigTest.java
@@ -3,6 +3,7 @@ package com.example.demo;
 import com.example.demo.chunk.CsvProcessor;
 import com.example.demo.chunk.CsvReader;
 import com.example.demo.chunk.CsvWriter;
+import com.example.demo.model.User;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.resource.CsvResource;
 import com.example.demo.tasklet.CsvExistsCheckTasklet1;
@@ -13,13 +14,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.item.file.MultiResourceItemReader;
+import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBatchTest
 // DI対象のクラスを列挙する
@@ -29,8 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @DisplayName("BatchConfigTest")
 public class BatchConfigTest {
 
+
   @Autowired
   private JobLauncherTestUtils jobLauncherTestUtils;
+
+  @Autowired
+  private CsvReader csvReader;
 
   @BeforeAll
   public static void beginTest() {
@@ -40,6 +48,27 @@ public class BatchConfigTest {
   @AfterAll
   public static void endTest() {
     log.info("BatchConfigTest 終了");
+  }
+
+  @Test
+  @DisplayName("readTest")
+  public void readTest(@Value("${csv.file.path}") String filePath) throws Exception {
+    // SETUP
+    log.info("readTest 開始");
+//    ReflectionTestUtils.setField(csvExistsCheckTasklet, "filePath", "", String.class);
+    final RepeatStatus expected = RepeatStatus.FINISHED;
+
+    // WHEN
+    MultiResourceItemReader<User> reader = csvReader.read(filePath);
+
+    // THEN
+    assertNotNull(reader.read());
+    assertNotNull(reader.read());
+    assertNotNull(reader.read());
+    assertNull(reader.read());
+
+    log.info("readTest 終了");
+
   }
 
   @Test

--- a/demo/src/test/java/com/example/demo/chunk/CsvReaderTest.java
+++ b/demo/src/test/java/com/example/demo/chunk/CsvReaderTest.java
@@ -2,12 +2,14 @@ package com.example.demo.chunk;
 
 import com.example.demo.model.User;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.item.file.MultiResourceItemReader;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -30,11 +32,6 @@ public class CsvReaderTest {
     log.info("CsvReaderTest 終了");
   }
 
-  @BeforeEach
-  public void setup() {
-    ReflectionTestUtils.setField(csvReader, "filePath", "classpath:test/csv/*.csv", String.class);
-  }
-
   @Test
   @DisplayName("readTest")
   public void readTest() throws Exception {
@@ -47,7 +44,7 @@ public class CsvReaderTest {
     };
 
     // WHEN
-    final MultiResourceItemReader<User> reader = csvReader.read();
+    final MultiResourceItemReader<User> reader = csvReader.read("classpath:test/csv/*.csv");
 
     assertEquals(expectedArray[0], reader.read());
     assertEquals(expectedArray[1], reader.read());

--- a/demo/src/test/java/com/example/demo/chunk/CsvWriterTest.java
+++ b/demo/src/test/java/com/example/demo/chunk/CsvWriterTest.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.batch.item.Chunk;
 
 import java.io.ByteArrayOutputStream;
@@ -22,7 +20,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 @Slf4j
 @DisplayName("CsvWriterTest")
 public class CsvWriterTest {

--- a/demo/src/test/java/com/example/demo/repository/UserRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/repository/UserRepositoryTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
-// @SpringBatchTest // SpringBatchの機能(Tasklet, Chunkなど)をテストするときに使うアノテーション
+// @SpringBatchTest // SpringBatchの機能(Job, Step)をテストするときに使うアノテーション
 @SpringBootTest // RepositoryはBatch機能ではないためSpringBootTestアノテーションを使用
 @Slf4j
 @DisplayName("UserRepositoryTest")


### PR DESCRIPTION
read処理がシングルトンとして処理されていた。
これによりバッチ起動→バッチ実行→ステップ処理の順に動くはずが、バッチ起動後にread処理が実行されていた。
これをマルチタイプとすることで解決